### PR TITLE
action.sh: skip zn_magisk_compat module

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -1,11 +1,16 @@
 #!/system/bin/env sh
 #
-# Enable all Magisk modules
-MODDIR="$(dirname "${0}")"
+# Enable all Magisk modules except zn_magisk_compat
 
-for mod in ${MODDIR}/../*; do
-  if [ -d "${mod}" ] && [ -f "${mod}/disable" ]; then
-    list="${list} ${mod}/disable"
+MODDIR="$(dirname "$0")"
+for mod in "$MODDIR"/../*; do
+  [ -d "$mod" ] || continue
+  # Skip zn_magisk_compat module
+  case "$mod" in
+    */zn_magisk_compat) continue ;;
+  esac
+  if [ -f "$mod/disable" ]; then
+    list="${list} $mod/disable"
   fi
 done
-[ -n "${list}" ] && rm -f -- ${list}
+[ -n "$list" ] && rm -f -- $list


### PR DESCRIPTION
- The module is auto generated by [ZygiskNext](https://github.com/Dr-TSNG/ZygiskNext) module, and is not recommended to be enabled.